### PR TITLE
Build simple children

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports.initialize = function (namespace, sails) {
         if (ns.active) {
             logger = ns.get('logger');
             if (logger) {
-                logger = logger.child(params);
+                logger = logger.child(params, true);
                 ns.set('logger', logger);
             }
         }


### PR DESCRIPTION
Non-simple child loggers have bugs when it comes to file rotation. See [node-bunyan #177](https://github.com/trentm/node-bunyan/issues/177).
