### PR TITLE
Manually run serializers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var logLevels = require('sails-bunyan').logLevels;
 var ns;
 
@@ -49,6 +50,15 @@ module.exports.initialize = function (namespace, sails) {
         if (ns.active) {
             logger = ns.get('logger');
             if (logger) {
+                // apply serializers to the params, b/c simple child loggers
+                // don't
+                params = _.mapValues(params, function (param, key) {
+                    var serializer = logger.serializers[key];
+                    if (!serializer) {
+                        return param;
+                    }
+                    return serializer(param);
+                });
                 logger = logger.child(params, true);
                 ns.set('logger', logger);
             }

--- a/package.json
+++ b/package.json
@@ -20,13 +20,16 @@
     "url": "https://github.com/erinspice/sails-bunyan-cls/issues"
   },
   "homepage": "https://github.com/erinspice/sails-bunyan-cls",
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^3.9.3"
+  },
   "devDependencies": {
     "mocha": "^1.21.4"
   },
   "peerDependencies": {
+    "sails-bunyan": "^1.x",
     "sails": "^0.10.4",
-    "bunyan": "^1.0.0"
+    "bunyan": "^1.x"
   },
   "maintainers": [
     {


### PR DESCRIPTION
When using simple children, they don't run the serializers...
intentionally. This patch runs the serializers manually when running
`.addContext()`.
